### PR TITLE
Fix: create non existing file directories for download cache and config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ impl Default for Config {
 
 pub fn write_config(cfg: &Config) -> Result<()> {
     let cereal = toml::to_string_pretty(cfg)?;
+    fs::create_dir_all(DIRS.config_dir())?;
     fs::write(DIRS.config_dir().join("config.toml"), cereal)?;
     Ok(())
 }

--- a/src/core/commands/northstar.rs
+++ b/src/core/commands/northstar.rs
@@ -53,6 +53,7 @@ fn init_ns(force: bool, path: Option<impl AsRef<Path>>) -> Result<()> {
         .get_item(&ModName::new("northstar", "Northstar", None))
         .ok_or(anyhow!("Couldn't find Northstar in the package index"))?;
 
+    std::fs::create_dir_all(DIRS.cache_dir())?;
     let mut nsfile = modfile!(DIRS
         .cache_dir()
         .join(format!("{}.zip", ModName::from(nsmod))))?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,29 +29,29 @@ macro_rules! flush {
 #[macro_export]
 macro_rules! modfile {
     ($path:expr) => {{
-        use std::fs::File;
-        File::options()
-            .create(true)
+        use std::fs::OpenOptions;
+        OpenOptions::new()
             .write(true)
+            .create(true)
             .read(true)
             .truncate(true)
             .open($path)
     }};
     (wo, $path:expr) => {{
-        use std::fs::File;
-        File::options()
+        use std::fs::OpenOptions;
+        OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
             .open($path)
     }};
     (ro, $path:expr) => {{
-        use std::fs::File;
-        File::options().create(true).read(true).open($path)
+        use std::fs::OpenOptions;
+        OpenOptions::new().create(true).read(true).open($path)
     }};
     (o, $path:expr) => {{
-        use std::fs::File;
-        File::options().read(true).write(true).open($path)
+        use std::fs::OpenOptions;
+        OpenOptions::new().read(true).write(true).open($path)
     }};
 }
 


### PR DESCRIPTION
Pretty sure this was just an oversight due to you already having the directories on your system.