### PR TITLE
feat (flake.nix): Use nightly toolchain to avoid building failures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,16 @@
           overlays = [fenix.overlays.default];
         };
 
-        naersk' = pkgs.callPackage naersk {};
+        toolchain = pkgs.fenix.latest.withComponents [
+          "cargo"
+          "rustc"
+        ];
+
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+
       in rec {
         defaultPackage = naersk'.buildPackage {
           src = ./.;


### PR DESCRIPTION
Currently, `nix build` doesn't work, because naersk is using stable rust channel by default, and it's not compatible with the used features of the language.
Fixed by specifying the latest cargo and rustc to be used by naersk.

## Error
```sh
 nix build
error: Cannot build '/nix/store/smk9zsdl0qsvk4623idxas910rcnwb6r-papa-4.1.0.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/alv91yzfp7v85y3ippwgdmc64rcbvs38-papa-4.1.0
       Last 25 log lines:
       > Running phase: buildPhase
       > cargo build $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format
       >    Compiling papa v4.1.0 (/build/source)
       > error: could not compile `papa` (bin "papa") due to 2 previous errors
       > error[E0554]: `#![feature]` may not be used on the stable release channel
       >  --> src/main.rs:1:1
       >   |
       > 1 | #![feature(let_chains)]
       >   | ^^^^^^^^^^^^^^^^^^^^^^^
       >
       >
```

## Testing
Confirmed that with this change, `nix build` doesn't output any errors and binary is present in the `result/bin` folder.